### PR TITLE
Slightly decrease the size of the docker artefact.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/install-checks.sh
+++ b/install-checks.sh
@@ -6,7 +6,7 @@ export ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export VIRTUALENV_DIR="${ROOT_DIR}/.venv"
 export TOOLS_DIR="${ROOT_DIR}/tools"
 export TMP_DIR="${TOOLS_DIR}/tmp"
-export NODE_MODULES_DIR="${TOOLS_DIR}/node_modules"
+export NODE_MODULES_DIR="${ROOT_DIR}/node_modules"
 export CONFIG_DIR="${ROOT_DIR}/config"
 # env vars for check executables
 export OPERA_CHECK_PATH="${VIRTUALENV_DIR}/bin/opera/"
@@ -90,10 +90,7 @@ installMarkdownLintIfNot() {
 
 installRequiredNpmModulesIfNot() {
   if [ ! -f "$NODE_MODULES_DIR" ]; then
-    cp package.json "${TOOLS_DIR}/package.json"
-    cp package-lock.json "${TOOLS_DIR}/package-lock.json"
-    npm i --prefix "${TOOLS_DIR}" --force
-    rm "${TOOLS_DIR}/package.json" "${TOOLS_DIR}/package-lock.json"
+    npm install --force
   fi
 }
 


### PR DESCRIPTION
The size went from 2.57 GB to 1.80 GB for a 770 MB reduction with things I dared remove. I also had to install `unzip` additionally because the install script needs it, but it doesn't fail. Things to decrease the size further:

* `opera` installs `ansible` instead of `ansible-core`. This means it installs 500 MB of collections automatically. Do we need this in opera? This is an instant saving. However, it must be done in xopera-opera as a new version with care for upgradability.
* `node_modules` are huge, If there's a way to install any node scanners differently, that'd reduce size. I merged two different `node_modules`
* Why is `openssh-client` installed?
* `sonar-scanner` distributes its own JRE (120 MB). Is there a distribution without it that uses the system JRE?

You need to check whether everything still runs fine since I removed things that may cause runtime to fail, such as replacing `ruby-full` with `ruby2.7`.