### PR TITLE
Recursive directory scan and result summary fix

### DIFF
--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -81,6 +81,10 @@ class Compatibility:
             self.scanned_files["yaml"] = str(scanned_yaml)
             self.scanned_files["java"] = str(scanned_java)
             self.scanned_files["html"] = str(scanned_html)
+            
+            types = set(types)
+            print(types)
+                        
             return types
         except Exception as e:
             raise Exception(f"Error when checking directory type: {str(e)}.")

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -48,48 +48,48 @@ class Compatibility:
         scanned_js = []
         scanned_docker = []
         scanned_other = []
-        
+           
         # TODO: List of supported file types should be extended
         # TODO: Remove hardcoded check names
         try:
-            for filename in os.listdir(iac_directory):
-                f = os.path.join(iac_directory, filename)
-                if os.path.isfile(f):
-                    if (f.find(".tf") or f.find(".tftpl")) > -1:
+            for root, folders, names in os.walk(iac_directory):
+                for f in names:
+                   print(f)
+                   if (f.find(".tf") or f.find(".tftpl")) > -1:
                         types.append("terraform")
-                        scanned_terraform.append(filename)
+                        scanned_terraform.append(f)
                     
-                    elif f.find(".sh") > -1:
+                   elif f.find(".sh") > -1:
                         types.append("shell")
-                        scanned_shell.append(filename)
+                        scanned_shell.append(f)
 
-                    elif f.find(".py") > -1:
+                   elif f.find(".py") > -1:
                         types.append("python")
-                        scanned_py.append(filename)
+                        scanned_py.append(f)
 
-                    elif (f.find(".yaml") or f.find(".yml")) > -1:
+                   elif (f.find(".yaml") or f.find(".yml")) > -1:
                         types.append("yaml")
-                        scanned_yaml.append(filename)
+                        scanned_yaml.append(f)
 
-                    elif f.find(".java") > -1:
+                   elif f.find(".java") > -1:
                         types.append("java")
-                        scanned_java.append(filename)
+                        scanned_java.append(f)
 
-                    elif f.find(".html") > -1:
+                   elif f.find(".html") > -1:
                         types.append("html")
-                        scanned_html.append(filename)
+                        scanned_html.append(f)
 
-                    elif f.find(".js") > -1:
+                   elif f.find(".js") > -1:
                         types.append("js")
-                        scanned_js.append(filename)
+                        scanned_js.append(f)
 
-                    elif f.find("Dockerfile") > -1:
+                   elif f.find("Dockerfile") > -1:
                         types.append("docker")
-                        scanned_docker.append(filename)                        
+                        scanned_docker.append(f)                        
 
-                    else: 
+                   else: 
                         types.append("other")
-                        scanned_other.append(filename)      
+                        scanned_other.append(f)      
                         
             self.scanned_files["terraform"] = str(scanned_terraform)
             self.scanned_files["python"] = str(scanned_py)

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -44,6 +44,7 @@ class Compatibility:
         scanned_yaml = []
         scanned_java = []
         scanned_html = []
+        scanned_js = []
 
         # TODO: List of supported file types should be extended
         # TODO: Remove hardcoded check names
@@ -75,13 +76,18 @@ class Compatibility:
                         types.append("html")
                         scanned_html.append(filename)
 
+                    if f.find(".js") > -1:
+                        types.append("js")
+                        scanned_js.append(filename)
+                        
             self.scanned_files["terraform"] = str(scanned_terraform)
             self.scanned_files["python"] = str(scanned_py)
             self.scanned_files["shell"] = str(scanned_shell)
             self.scanned_files["yaml"] = str(scanned_yaml)
             self.scanned_files["java"] = str(scanned_java)
             self.scanned_files["html"] = str(scanned_html)
-            
+            self.scanned_files["js"] = str(scanned_js)
+                        
             types = set(types)
             print(types)
                         

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -54,7 +54,6 @@ class Compatibility:
         try:
             for root, folders, names in os.walk(iac_directory):
                 for f in names:
-                   print(f)
                    if (f.find(".tf") or f.find(".tftpl")) > -1:
                         types.append("terraform")
                         scanned_terraform.append(f)

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -13,7 +13,7 @@ class Compatibility:
         "js": ["es-lint", "ts-lint"],
         "html": ["htmlhint"],
         "docker": ["hadolint"],
-        "other": [""],        
+        "other": [],        
     }
     
     def __init__(self):
@@ -101,8 +101,7 @@ class Compatibility:
             self.scanned_files["other"] = str(scanned_other)
                                                 
             types = set(types)
-            print(types)
-                        
+                                    
             return types
         except Exception as e:
             raise Exception(f"Error when checking directory type: {str(e)}.")

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -13,6 +13,7 @@ class Compatibility:
         "js": ["es-lint", "ts-lint"],
         "html": ["htmlhint"],
         "docker": ["hadolint"],
+        "other": [""],        
     }
     
     def __init__(self):
@@ -45,40 +46,50 @@ class Compatibility:
         scanned_java = []
         scanned_html = []
         scanned_js = []
-
+        scanned_docker = []
+        scanned_other = []
+        
         # TODO: List of supported file types should be extended
         # TODO: Remove hardcoded check names
         try:
             for filename in os.listdir(iac_directory):
                 f = os.path.join(iac_directory, filename)
                 if os.path.isfile(f):
-                    if f.find(".tf") > -1:
+                    if (f.find(".tf") or f.find(".tftpl")) > -1:
                         types.append("terraform")
                         scanned_terraform.append(filename)
-
-                    if f.find(".sh") > -1:
+                    
+                    elif f.find(".sh") > -1:
                         types.append("shell")
                         scanned_shell.append(filename)
 
-                    if f.find(".py") > -1:
+                    elif f.find(".py") > -1:
                         types.append("python")
                         scanned_py.append(filename)
 
-                    if f.find(".yaml") > -1:
+                    elif (f.find(".yaml") or f.find(".yml")) > -1:
                         types.append("yaml")
                         scanned_yaml.append(filename)
 
-                    if f.find(".java") > -1:
+                    elif f.find(".java") > -1:
                         types.append("java")
                         scanned_java.append(filename)
 
-                    if f.find(".html") > -1:
+                    elif f.find(".html") > -1:
                         types.append("html")
                         scanned_html.append(filename)
 
-                    if f.find(".js") > -1:
+                    elif f.find(".js") > -1:
                         types.append("js")
                         scanned_js.append(filename)
+
+                    elif f.find("Dockerfile") > -1:
+                        types.append("docker")
+                        scanned_docker.append(filename)                        
+
+                    else: 
+                        types.append("other")
+                        scanned_other.append(filename)      
                         
             self.scanned_files["terraform"] = str(scanned_terraform)
             self.scanned_files["python"] = str(scanned_py)
@@ -87,7 +98,9 @@ class Compatibility:
             self.scanned_files["java"] = str(scanned_java)
             self.scanned_files["html"] = str(scanned_html)
             self.scanned_files["js"] = str(scanned_js)
-                        
+            self.scanned_files["docker"] = str(scanned_docker)
+            self.scanned_files["other"] = str(scanned_other)
+                                                
             types = set(types)
             print(types)
                         

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -102,7 +102,6 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Passed"
                 return "Problems"  
 
-
         if check == "pylint":
             if outcome.find("no problems")>-1:
                 self.outcomes[check]["status"] = "Passed"
@@ -110,6 +109,18 @@ class ResultsSummary:
             else:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
+
+        if check == "hadolint":
+            if outcome=="":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems" 
+
+        if check == "other":
+            self.outcomes[check]["status"] = "No scan performed"
+            return "No scan"
 
 
     def summarize_no_files(self, check: str):

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -96,7 +96,7 @@ class ResultsSummary:
 
         if check == "ts-lint":
             if outcome.find("wrong")>-1:
-                self.outcomes[check]["status"] = "Prolems"
+                self.outcomes[check]["status"] = "Problems"
                 return "Passed"
             else:
                 self.outcomes[check]["status"] = "Passed"

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -46,6 +46,7 @@ class ResultsSummary:
         
         # TODO: This part should be extended to cover all relevant cases and code refactored
         # TODO: The check names hould not be hardcoded but replaced with parametrized values instead
+        # TODO: Extract "Passed" and "Problems" into an Enum object and use them
         if check == "tfsec":
             if outcome.find("No problems detected!") > -1:
                 self.outcomes[check]["status"] = "Passed"

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -70,6 +70,30 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
+        if check == "htmlhint":
+            if outcome.find("no errors")>-1:
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"
+
+        if check == "checkstyle":
+            if outcome == "":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"                
+
+        if check == "es-lint":
+            if outcome == "":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"      
+
     def summarize_no_files(self, check: str):
         """
         Sets the outcome of the selected check to "no files" case

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -102,6 +102,16 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Passed"
                 return "Problems"  
 
+
+        if check == "pylint":
+            if outcome.find("no problems")>-1:
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems" 
+
+
     def summarize_no_files(self, check: str):
         """
         Sets the outcome of the selected check to "no files" case

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -87,12 +87,20 @@ class ResultsSummary:
                 return "Problems"                
 
         if check == "es-lint":
-            if outcome == "":
-                self.outcomes[check]["status"] = "Passed"
+            if outcome.find("wrong")>-1:
+                self.outcomes[check]["status"] = "Problems"
                 return "Passed"
             else:
-                self.outcomes[check]["status"] = "Problems"
+                self.outcomes[check]["status"] = "Passed"
                 return "Problems"      
+
+        if check == "ts-lint":
+            if outcome.find("wrong")>-1:
+                self.outcomes[check]["status"] = "Prolems"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Passed"
+                return "Problems"  
 
     def summarize_no_files(self, check: str):
         """

--- a/src/iac_scan_runner/scan_runner.py
+++ b/src/iac_scan_runner/scan_runner.py
@@ -155,21 +155,17 @@ class ScanRunner:
                         scan_output[selected_check] = check_output.to_dict()                        
                         write_string_to_file(check.name, dir_name, scan_output[check.name]["output"])
                         self.results_summary.summarize_outcome(selected_check, scan_output[check.name]["output"], self.compatibility_matrix.scanned_files, Compatibility.compatibility_matrix)
-                        
                     else:
                         non_compatible_checks.append(check.name)
                         write_string_to_file(check.name, dir_name, "No files to scan")
                         self.results_summary.summarize_no_files(check.name)
-
             self.results_summary.dump_outcomes(random_uuid)
             self.results_summary.generate_html_prioritized(random_uuid)
- 
         else:
             for iac_check in self.iac_checks.values():
                 if iac_check.enabled:
                     check_output = iac_check.run(self.iac_dir)
                     scan_output[iac_check.name] = check_output.to_dict()
-
                 # TODO: Discuss the format of this output
                 write_string_to_file(
                     iac_check.name, dir_name, scan_output[iac_check.name]["output"]

--- a/src/iac_scan_runner/utils.py
+++ b/src/iac_scan_runner/utils.py
@@ -97,3 +97,18 @@ def write_html_to_file(file_name: str, output_value: str):
             text_file.write(output_value)
     except Exception as e:
         raise Exception(f"Error storing HTML to file: {str(e)}.")           
+
+
+def file_to_string(file_path: str):
+    """
+    Reads the file given by path and returns its contents as string output
+    :param file_path: Path of the file
+    :return output: Content read from file in form of a string
+    """
+    output = ""
+    try:
+        with open(file_path, "r") as text_file:
+            output = str(text_file.read())
+    except Exception as e:
+        raise Exception(f"Error while reading file: {str(e)}.")           
+    return output        

--- a/src/iac_scan_runner/utils.py
+++ b/src/iac_scan_runner/utils.py
@@ -99,7 +99,7 @@ def write_html_to_file(file_name: str, output_value: str):
         raise Exception(f"Error storing HTML to file: {str(e)}.")           
 
 
-def file_to_string(file_path: str):
+def file_to_string(file_path: str) -> str:
     """
     Reads the file given by path and returns its contents as string output
     :param file_path: Path of the file

--- a/src/iac_scan_runner/utils.py
+++ b/src/iac_scan_runner/utils.py
@@ -109,6 +109,7 @@ def file_to_string(file_path: str) -> str:
     try:
         with open(file_path, "r") as text_file:
             output = str(text_file.read())
+    # TODO: Narrow exceptions for this one and similar functions        
     except Exception as e:
         raise Exception(f"Error while reading file: {str(e)}.")           
     return output        


### PR DESCRIPTION
- added support for recursive subdirectory traversal within IaC archive
- fixed the outputs of several tools (checkstyle, hadolint, htmlhint, ts-lint, es-lint)
- fixed the bug related to additional extensions within Terraform and Tosca archives
- covering the scenario for unsupported file types within IaC archive