### PR TITLE
Fixed output for scenario when there is no list of desired scans

### DIFF
--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -5,10 +5,10 @@ class Compatibility:
     # TODO: This matrix should be revised and extended, it is just a proof of concept here as for now
     compatibility_matrix = {
         "terraform": ["tfsec", "tflint", "terrascan", "git-leaks", "git-secrets"],
-        "yaml": ["git-leaks", "yamllint", "git-secrets"],
+        "yaml": ["git-leaks", "yamllint", "git-secrets", "ansible-lint", "steampunk-scanner"],
         "shell": ["shellcheck", "git-leaks", "git-secrets"],
         "python": ["pylint", "bandit", "pyup-safety"],
-        "ansible": ["ansible-lint", "steampunk-scanner"],
+        #"ansible": ["ansible-lint", "steampunk-scanner"],
         "java": ["checkstyle"],
         "js": ["es-lint", "ts-lint"],
         "html": ["htmlhint"],
@@ -54,9 +54,15 @@ class Compatibility:
         try:
             for root, folders, names in os.walk(iac_directory):
                 for f in names:
-                   if (f.find(".tf") or f.find(".tftpl")) > -1:
+                   print(f)
+                   if (f.find(".tf") > -1) or (f.find(".tftpl") > -1):
                         types.append("terraform")
                         scanned_terraform.append(f)
+
+                   elif (f.find(".yaml") > -1) or (f.find(".yml") > -1):
+                        print(f)
+                        types.append("yaml")
+                        scanned_yaml.append(f)
                     
                    elif f.find(".sh") > -1:
                         types.append("shell")
@@ -65,10 +71,6 @@ class Compatibility:
                    elif f.find(".py") > -1:
                         types.append("python")
                         scanned_py.append(f)
-
-                   elif (f.find(".yaml") or f.find(".yml")) > -1:
-                        types.append("yaml")
-                        scanned_yaml.append(f)
 
                    elif f.find(".java") > -1:
                         types.append("java")

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -5,7 +5,7 @@ class Compatibility:
     # TODO: This matrix should be revised and extended, it is just a proof of concept here as for now
     compatibility_matrix = {
         "terraform": ["tfsec", "tflint", "terrascan", "git-leaks", "git-secrets"],
-        "yaml": ["git-leaks", "yamllint", "git-leaks", "git-secrets"],
+        "yaml": ["git-leaks", "yamllint", "git-secrets"],
         "shell": ["shellcheck", "git-leaks", "git-secrets"],
         "python": ["pylint", "bandit", "pyup-safety"],
         "ansible": ["ansible-lint", "steampunk-scanner"],

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -13,7 +13,7 @@ class Compatibility:
         "js": ["es-lint", "ts-lint"],
         "html": ["htmlhint"],
         "docker": ["hadolint"],
-        "other": [],        
+        "other": ["git-leaks", "git-secrets"],        
     }
     
     def __init__(self):

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -54,13 +54,11 @@ class Compatibility:
         try:
             for root, folders, names in os.walk(iac_directory):
                 for f in names:
-                   print(f)
                    if (f.find(".tf") > -1) or (f.find(".tftpl") > -1):
                         types.append("terraform")
                         scanned_terraform.append(f)
 
                    elif (f.find(".yaml") > -1) or (f.find(".yml") > -1):
-                        print(f)
                         types.append("yaml")
                         scanned_yaml.append(f)
                     

--- a/src/iac_scan_runner/compatibility.py
+++ b/src/iac_scan_runner/compatibility.py
@@ -4,16 +4,16 @@ from typing import List
 class Compatibility:
     # TODO: This matrix should be revised and extended, it is just a proof of concept here as for now
     compatibility_matrix = {
-        "terraform": ["tfsec", "tflint", "terrascan", "git-leaks", "git-secrets"],
-        "yaml": ["git-leaks", "yamllint", "git-secrets", "ansible-lint", "steampunk-scanner"],
-        "shell": ["shellcheck", "git-leaks", "git-secrets"],
-        "python": ["pylint", "bandit", "pyup-safety"],
-        #"ansible": ["ansible-lint", "steampunk-scanner"],
-        "java": ["checkstyle"],
-        "js": ["es-lint", "ts-lint"],
-        "html": ["htmlhint"],
-        "docker": ["hadolint"],
-        "other": ["git-leaks", "git-secrets"],        
+        "terraform": ["tfsec", "tflint", "terrascan", "git-leaks", "git-secrets", "cloc"],
+        "yaml": ["git-leaks", "yamllint", "git-secrets", "ansible-lint", "steampunk-scanner", "cloc"],
+        "shell": ["shellcheck", "git-leaks", "git-secrets", "cloc"],
+        "python": ["pylint", "bandit", "pyup-safety", "cloc"],
+        "java": ["checkstyle", "cloc"],
+        "js": ["es-lint", "ts-lint", "cloc"],
+        "html": ["htmlhint", "cloc"],
+        "docker": ["hadolint", "cloc"],
+        "common":  ["git-leaks", "git-secrets", "cloc"], 
+        "other": []        
     }
     
     def __init__(self):
@@ -48,12 +48,13 @@ class Compatibility:
         scanned_js = []
         scanned_docker = []
         scanned_other = []
-           
+        scanned_all = []           
         # TODO: List of supported file types should be extended
         # TODO: Remove hardcoded check names
         try:
             for root, folders, names in os.walk(iac_directory):
                 for f in names:
+                   scanned_all.append(f)
                    if (f.find(".tf") > -1) or (f.find(".tftpl") > -1):
                         types.append("terraform")
                         scanned_terraform.append(f)
@@ -89,6 +90,8 @@ class Compatibility:
                    else: 
                         types.append("other")
                         scanned_other.append(f)      
+            
+            types.append("common")
                         
             self.scanned_files["terraform"] = str(scanned_terraform)
             self.scanned_files["python"] = str(scanned_py)
@@ -99,6 +102,7 @@ class Compatibility:
             self.scanned_files["js"] = str(scanned_js)
             self.scanned_files["docker"] = str(scanned_docker)
             self.scanned_files["other"] = str(scanned_other)
+            self.scanned_files["common"] = str(scanned_all)            
                                                 
             types = set(types)
                                     

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -63,6 +63,22 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
+        elif check == "terrascan":
+            if outcome == "":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"
+
+        elif check == "steampunk-scanner":
+            if outcome == "":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"
+
         elif check == "tflint":
             if outcome == "":
                 self.outcomes[check]["status"] = "Passed"

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -40,6 +40,7 @@ class ResultsSummary:
         file_list = ""
         for t in compatibility_matrix:
             if check in compatibility_matrix[t]:
+                print(compatibility_matrix[t])
                 file_list = str(scanned_files[t])
 
         self.outcomes[check]["files"] = file_list
@@ -55,7 +56,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
-        if check == "git-leaks":
+        elif check == "git-leaks":
             if outcome.find("No leaks found") > -1:
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -63,7 +64,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
-        if check == "tflint":
+        elif check == "tflint":
             if outcome == "":
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -71,7 +72,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
-        if check == "htmlhint":
+        elif check == "htmlhint":
             if outcome.find("no errors")>-1:
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -79,7 +80,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
-        if check == "checkstyle":
+        elif check == "checkstyle":
             if outcome == "":
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -87,7 +88,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"                
 
-        if check == "es-lint":
+        elif check == "es-lint":
             if outcome.find("wrong")>-1:
                 self.outcomes[check]["status"] = "Problems"
                 return "Passed"
@@ -95,7 +96,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Passed"
                 return "Problems"      
 
-        if check == "ts-lint":
+        elif check == "ts-lint":
             if outcome.find("wrong")>-1:
                 self.outcomes[check]["status"] = "Problems"
                 return "Passed"
@@ -103,7 +104,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Passed"
                 return "Problems"  
 
-        if check == "pylint":
+        elif check == "pylint":
             if outcome.find("no problems")>-1:
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -111,7 +112,7 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
 
-        if check == "hadolint":
+        elif check == "hadolint":
             if outcome=="":
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
@@ -119,20 +120,23 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
 
-        if check == "terrascan":
+        elif check == "terrascan":
             if outcome=="":
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
             else:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
-                
-        if check == "other":
-            self.outcomes[check]["status"] = "No scan performed"
-            return "No scan"
-        else:
-            self.outcomes[check]["status"] = "Not fully supported yet"
-            return "Not fully supported yet"
+
+        elif check == "ansible-lint":
+            if outcome=="":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems" 
+        self.outcomes[check]["status"] = "Not fully supported yet"
+        return "Not fully supported yet"
 
     def summarize_no_files(self, check: str):
         """

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -119,10 +119,20 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
 
+        if check == "terrascan":
+            if outcome=="":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems" 
+                
         if check == "other":
             self.outcomes[check]["status"] = "No scan performed"
             return "No scan"
-
+        else:
+            self.outcomes[check]["status"] = "Not fully supported yet"
+            return "Not fully supported yet"
 
     def summarize_no_files(self, check: str):
         """

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -63,6 +63,14 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
+        elif check == "git-secrets":
+            if outcome=="":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"
+
         elif check == "terrascan":
             if outcome == "":
                 self.outcomes[check]["status"] = "Passed"
@@ -159,6 +167,10 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems" 
 
+        elif check == "cloc":
+            self.outcomes[check]["status"] = "Info"
+            return "Info"
+                
         elif check == "ansible-lint":
             if outcome=="":
                 self.outcomes[check]["status"] = "Passed"
@@ -231,6 +243,17 @@ class ResultsSummary:
                 html_page = html_page + "<tr>"
                 html_page = html_page + "<td>" + scan + "</td>"
                 html_page = html_page + "<td bgcolor='green'>" + str(self.outcomes[scan]["status"]) + "</td>"
+
+                html_page = html_page + "<td>" + self.outcomes[scan]["files"] + "</td>"
+                html_page = html_page + "<td>" + self.outcomes[scan]["log"] + "</td>"
+                html_page = html_page + "</tr>"
+
+        for scan in self.outcomes:
+
+            if self.outcomes[scan]["status"] == "Info":
+                html_page = html_page + "<tr>"
+                html_page = html_page + "<td>" + scan + "</td>"
+                html_page = html_page + "<td bgcolor='yellow'>" + str(self.outcomes[scan]["status"]) + "</td>"
 
                 html_page = html_page + "<td>" + self.outcomes[scan]["files"] + "</td>"
                 html_page = html_page + "<td>" + self.outcomes[scan]["log"] + "</td>"

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -87,6 +87,14 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"                
 
+        elif check == "shellcheck":
+            if outcome == "":
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"   
+
         elif check == "es-lint":
             if outcome.find("wrong")>-1:
                 self.outcomes[check]["status"] = "Problems"
@@ -105,6 +113,14 @@ class ResultsSummary:
 
         elif check == "pylint":
             if outcome.find("no problems")>-1:
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+            else:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems" 
+
+        elif check == "bandit":
+            if outcome.find("No issues identified.")>-1:
                 self.outcomes[check]["status"] = "Passed"
                 return "Passed"
             else:

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -40,7 +40,6 @@ class ResultsSummary:
         file_list = ""
         for t in compatibility_matrix:
             if check in compatibility_matrix[t]:
-                print(compatibility_matrix[t])
                 file_list = str(scanned_files[t])
 
         self.outcomes[check]["files"] = file_list

--- a/src/iac_scan_runner/scan_runner.py
+++ b/src/iac_scan_runner/scan_runner.py
@@ -146,13 +146,15 @@ class ScanRunner:
 
         compatible_checks = self.compatibility_matrix.get_all_compatible_checks(self.iac_dir)
         non_compatible_checks = []
-                
         scan_output = {}
-
-        if selected_checks and selected_checks!="":
+        
+        if selected_checks:
             for selected_check in selected_checks:
                 check = self.iac_checks[selected_check]
+                print(selected_check)
                 if check.enabled:
+                    print("enabled")
+                    print(compatible_checks)
                     if selected_check in compatible_checks:
                         check_output = check.run(self.iac_dir)
                         scan_output[selected_check] = check_output.to_dict()                        

--- a/src/iac_scan_runner/scan_runner.py
+++ b/src/iac_scan_runner/scan_runner.py
@@ -140,14 +140,16 @@ class ScanRunner:
         dir_name = "../outputs/logs/scan_run_" + random_uuid
 
         os.mkdir(dir_name)
+        
+        self.results_summary.outcomes = dict()
+        self.compatibility_matrix.scanned_files = dict()
 
         compatible_checks = self.compatibility_matrix.get_all_compatible_checks(self.iac_dir)
-        print(compatible_checks)
         non_compatible_checks = []
-
+                
         scan_output = {}
 
-        if selected_checks:
+        if selected_checks and selected_checks!="":
             for selected_check in selected_checks:
                 check = self.iac_checks[selected_check]
                 if check.enabled:
@@ -163,12 +165,9 @@ class ScanRunner:
             self.results_summary.dump_outcomes(random_uuid)
             self.results_summary.generate_html_prioritized(random_uuid)
         else:
-            print("Else")
             for iac_check in self.iac_checks.values():
                 if iac_check.enabled:
                     if iac_check.name in compatible_checks:
-                        print("run")                    
-                        print(iac_check.name)
                         check_output = iac_check.run(self.iac_dir)
                         scan_output[iac_check.name] = check_output.to_dict()                  
                         write_string_to_file(iac_check.name, dir_name, scan_output[iac_check.name]["output"])

--- a/src/iac_scan_runner/scan_runner.py
+++ b/src/iac_scan_runner/scan_runner.py
@@ -143,7 +143,6 @@ class ScanRunner:
         
         self.results_summary.outcomes = dict()
         self.compatibility_matrix.scanned_files = dict()
-
         compatible_checks = self.compatibility_matrix.get_all_compatible_checks(self.iac_dir)
         non_compatible_checks = []
         scan_output = {}
@@ -151,10 +150,7 @@ class ScanRunner:
         if selected_checks:
             for selected_check in selected_checks:
                 check = self.iac_checks[selected_check]
-                print(selected_check)
                 if check.enabled:
-                    print("enabled")
-                    print(compatible_checks)
                     if selected_check in compatible_checks:
                         check_output = check.run(self.iac_dir)
                         scan_output[selected_check] = check_output.to_dict()                        


### PR DESCRIPTION
After applying this fix, errors due to presence of compatibility matrix feature presence in case of no scan tools listed as argument will be avoided. 