### PR TITLE
Fixed typo in scan function

### DIFF
--- a/src/iac_scan_runner/scan_runner.py
+++ b/src/iac_scan_runner/scan_runner.py
@@ -283,7 +283,7 @@ class ScanRunner:
             end_time = time.time()
             duration = end_time-start_time
 
-            self.results_summary.set_result(random_uuid, archive_name, duration)   
+            self.results_summary.set_result(random_uuid, self.archive_name, duration)   
               
             if self.users_enabled:
                 self.results_summary.outcomes["projectid"] = projectid 


### PR DESCRIPTION
After applying this commit:
- scan function would properly use the project's persisted list (coming from DB) of enabled checks in all cases