### PR TITLE
Added support for steampunk output rendering within HTML page

### DIFF
--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -196,7 +196,7 @@ class ResultsSummary:
                 return "Passed"
             else:
                 self.outcomes[check]["status"] = "Problems"
-                return "Problems"        
+                return "Problems" 
 
         elif check == "yamllint":
             if outcome.find("error") > -1:

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -178,6 +178,14 @@ class ResultsSummary:
                 self.outcomes[check]["status"] = "Problems"
                 return "Problems"
 
+        elif check == "steampunk-scanner":
+            if outcome.find("ERROR") > -1:
+                self.outcomes[check]["status"] = "Problems"
+                return "Problems"
+            else:
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+
         elif check == "cloc":
             self.outcomes[check]["status"] = "Info"
             return "Info"

--- a/src/iac_scan_runner/results_summary.py
+++ b/src/iac_scan_runner/results_summary.py
@@ -196,7 +196,16 @@ class ResultsSummary:
                 return "Passed"
             else:
                 self.outcomes[check]["status"] = "Problems"
+                return "Problems"        
+
+        elif check == "yamllint":
+            if outcome.find("error") > -1:
+                self.outcomes[check]["status"] = "Problems"
                 return "Problems"
+            else:
+                self.outcomes[check]["status"] = "Passed"
+                return "Passed"
+
         self.outcomes[check]["status"] = "Not fully supported yet"
         return "Not fully supported yet"
 


### PR DESCRIPTION
Applying this commit will:
- include steampunk-scanner results outcome (passed/problems) inside HTML output page