### PR TITLE
Set project id as required field on scan

### DIFF
--- a/src/iac_scan_runner/model/Scan.py
+++ b/src/iac_scan_runner/model/Scan.py
@@ -9,6 +9,24 @@ class ScanModel(BaseModel):
     Scan model
     """
     iac: UploadFile
+
+    @classmethod
+    def as_form(cls,
+                iac: UploadFile = File(default=None,
+                                       description='IaC file (zip or tar compressed) that will be scanned')):
+        """
+        Converts model to form_data structure for FastAPI
+
+        :param iac: zip file of documents to be scanned
+        """
+        return cls(iac=iac)
+
+
+class ScanModelDeprecated(BaseModel):
+    """
+    Deprecated Scan model
+    """
+    iac: UploadFile
     checks: Optional[List[str]]
 
     @classmethod

--- a/src/iac_scan_runner/routers/project.py
+++ b/src/iac_scan_runner/routers/project.py
@@ -36,8 +36,7 @@ async def post_new_project(creator_id: str) -> JSONResponse:
 
 
 @router.post("/scan", summary="Initiate IaC scan", responses={200: {}, 400: {"model": str}})
-async def post_scan(form_data: ScanModel = Depends(ScanModel.as_form),
-                    project_id: Optional[str] = None,
+async def post_scan(project_id: str, form_data: ScanModel = Depends(ScanModel.as_form),
                     scan_response_type: ScanResponseType = ScanResponseType.json) -> Union[JSONResponse, HTMLResponse]:
     """
     Run IaC scan


### PR DESCRIPTION
In this MR we set project id as required field in all endpoints that use project id. Additionally some code cleanup was done.