### PR TITLE
Fix checkstyle variable name in install-checks

### DIFF
--- a/install-checks.sh
+++ b/install-checks.sh
@@ -67,8 +67,8 @@ removeDir() {
 }
 
 downloadCheckStyleJarIfNot() {
-  if [ ! -f "$CHECK_STYLE_PATH" ]; then
-    wget ${checkStyleUrl} -O "${CHECK_STYLE_PATH}"
+  if [ ! -f "$CHECKSTYLE_CHECK_PATH" ]; then
+    wget ${checkStyleUrl} -O "${CHECKSTYLE_CHECK_PATH}"
   fi
 }
 


### PR DESCRIPTION
Fixed the variable used in the installation of the Checkstyle check, as the one used before did not exist/was a typo.