### PR TITLE
Update CLI call for Tflint

### DIFF
--- a/src/iac_scan_runner/checks/tflint.py
+++ b/src/iac_scan_runner/checks/tflint.py
@@ -26,5 +26,5 @@ class TFLintCheck(Check):
     def run(self, directory: str) -> CheckOutput:
         """Run check."""
         if self._config_filename:
-            return run_command(f"{env.TFLINT_CHECK_PATH} -c {env.CONFIG_DIR}/{self._config_filename} .", directory)
-        return run_command(f"{env.TFLINT_CHECK_PATH} .", directory)
+            return run_command(f"{env.TFLINT_CHECK_PATH} -c {env.CONFIG_DIR}/{self._config_filename} --filter=.", directory)
+        return run_command(f"{env.TFLINT_CHECK_PATH} --filter=.", directory)


### PR DESCRIPTION
Command line arguments support was dropped in v0.47. Now "--filter=." is used instead of "."