### PR TITLE
Update root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ $ python3 -m venv .venv && . .venv/bin/activate
 (.venv) $ pip install -r requirements.txt
 (.venv) $ ./install-checks.sh
 # run IaC Scan Runner REST API (add --reload flag to apply code changes on the way)
-(.venv) $ cd src
-(.venv) $ uvicorn iac_scan_runner.api:app
+(.venv) $ uvicorn src.iac_scan_runner.api:app
 ```
 
 ## Usage and examples

--- a/src/iac_scan_runner/functionality/results_summary.py
+++ b/src/iac_scan_runner/functionality/results_summary.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Dict
 
 from iac_scan_runner.utils import write_html_to_file
+import iac_scan_runner.vars as env
 
 
 class ResultsSummary:
@@ -223,8 +224,7 @@ class ResultsSummary:
 
         :param file_name: Name of the generated JSON file containing the scan summary
         """
-        # TODO: Replace hardcoded path with parameter
-        file_path = "../outputs/json_dumps/" + file_name + ".json"
+        file_path = f"{env.ROOT_DIR}/outputs/json_dumps/" + file_name + ".json"
 
         try:
             with open(file_path, "w", encoding="utf-8") as file:
@@ -262,7 +262,7 @@ class ResultsSummary:
 
         :param file_name: Name of the generated HTML file containing the page summary
         """
-        with open("./iac_scan_runner/asset/response.html", "r", encoding="utf-8") as html_template:
+        with open("src/iac_scan_runner/asset/response.html", "r", encoding="utf-8") as html_template:
             html = html_template.read()
 
         html = html.replace("CHANGE_ARCHIVE_NAME", self.outcomes["archive"])
@@ -274,7 +274,7 @@ class ResultsSummary:
             html = html.replace("CHANGE_FINAL_VERDICT", "No issues found")  # noqa: F841
 
         table_content = ""
-        with open("./iac_scan_runner/asset/table_problem.html", "r", encoding="utf-8") as html_template:
+        with open("src/iac_scan_runner/asset/table_problem.html", "r", encoding="utf-8") as html_template:
             html_problem = html_template.read()
         for scan in self.outcomes:
             if scan not in ["uuid", "time", "archive", "execution-duration", "verdict", "project_id"] \
@@ -286,7 +286,7 @@ class ResultsSummary:
                 changeable_html = changeable_html.replace("CHANGE_LOG", self.outcomes[scan]["log"])
                 table_content += changeable_html
 
-        with open("./iac_scan_runner/asset/table_info.html", "r", encoding="utf-8") as html_template:
+        with open("src/iac_scan_runner/asset/table_info.html", "r", encoding="utf-8") as html_template:
             html_problem = html_template.read()
         for scan in self.outcomes:
             if scan not in ["uuid", "time", "archive", "execution-duration", "verdict", "project_id"] \
@@ -298,7 +298,7 @@ class ResultsSummary:
                 changeable_html = changeable_html.replace("CHANGE_LOG", self.outcomes[scan]["log"])
                 table_content += changeable_html
 
-        with open("./iac_scan_runner/asset/table_basic.html", "r", encoding="utf-8") as html_template:
+        with open("src/iac_scan_runner/asset/table_basic.html", "r", encoding="utf-8") as html_template:
             html_problem = html_template.read()
         for scan in self.outcomes:
             if scan not in ["uuid", "time", "archive", "execution-duration", "verdict", "project_id"] \

--- a/src/iac_scan_runner/functionality/scan_runner.py
+++ b/src/iac_scan_runner/functionality/scan_runner.py
@@ -162,7 +162,7 @@ class ScanRunner:
         start_time = time.time()
         random_uuid = str(uuid.uuid4())
 
-        dir_name = "../outputs/logs/scan_run_" + random_uuid
+        dir_name = "outputs/logs/scan_run_" + random_uuid
         os.mkdir(dir_name)
 
         self.results_summary.outcomes = {}
@@ -199,9 +199,9 @@ class ScanRunner:
                 self.results_persistence.insert_result(self.results_summary.outcomes)
 
         if scan_response_type == ScanResponseType.JSON:
-            scan_output = json.loads(file_to_string(f"../outputs/json_dumps/{random_uuid}.json"))
+            scan_output = json.loads(file_to_string(f"{env.ROOT_DIR}/outputs/json_dumps/{random_uuid}.json"))
         else:
-            scan_output = file_to_string(f"../outputs/generated_html/{random_uuid}.html")
+            scan_output = file_to_string(f"{env.ROOT_DIR}/outputs/generated_html/{random_uuid}.html")
 
         return scan_output
 

--- a/src/iac_scan_runner/utils.py
+++ b/src/iac_scan_runner/utils.py
@@ -11,6 +11,7 @@ from zipfile import is_zipfile
 from bson import json_util
 
 from iac_scan_runner.functionality.check_output import CheckOutput
+import iac_scan_runner.vars as env
 
 
 def run_command(command: str, directory: str = ".") -> CheckOutput:
@@ -98,7 +99,7 @@ def write_html_to_file(file_name: str, output_value: str) -> None:
     :param file_name: File name
     :param output_value: Content written to given file
     """
-    file_name = "../outputs/generated_html/" + file_name + ".html"
+    file_name = f"{env.ROOT_DIR}/outputs/generated_html/" + file_name + ".html"
     try:
         with open(file_name, "w", encoding="utf-8") as text_file:
             text_file.write(output_value)

--- a/src/iac_scan_runner/vars.py
+++ b/src/iac_scan_runner/vars.py
@@ -1,7 +1,7 @@
 import os
 
 # vars for paths to directories
-ROOT_DIR = os.getenv("ROOT_DIR", os.path.normpath(os.getcwd() + os.sep + os.pardir))
+ROOT_DIR = os.getenv("ROOT_DIR", os.path.normpath(os.getcwd()))
 VIRTUALENV_DIR = os.getenv("VIRTUALENV_DIR", f"{ROOT_DIR}/.venv")
 TOOLS_DIR = os.getenv("TOOLS_DIR", f"{ROOT_DIR}/tools")
 CONFIG_DIR = os.getenv("CONFIG_DIR", f"{ROOT_DIR}/config")


### PR DESCRIPTION
Root directory was previously being set based on the instructions of setting up the api server, which meant that it was "src". By running the api server in root directory "iac-scan-runner" instead of in "src", the relative paths become simpler and tests are easier to run on local machines.

Root directory is now set to "iac-scan-runnner" instead of "iac-scan-runner/src".