### PR TITLE
Bugfix/94 compatibility matrix

### DIFF
--- a/src/iac_scan_runner/functionality/compatibility.py
+++ b/src/iac_scan_runner/functionality/compatibility.py
@@ -15,6 +15,9 @@ class Compatibility:
         "js": ["es-lint", "ts-lint", "cloc"],
         "html": ["htmlhint", "cloc"],
         "docker": ["hadolint", "cloc"],
+        "markdown": ["markdown-lint", "cloc"],
+        "css": ["stylelint", "cloc"],
+        "nginx": ["gixy", "cloc"],
         "common": ["git-leaks", "git-secrets", "cloc"],
         "other": []
     }
@@ -49,6 +52,9 @@ class Compatibility:
         scanned_html = []
         scanned_js = []
         scanned_docker = []
+        scanned_markdown = []        
+        scanned_css = []
+        scanned_nginx = []
         scanned_other = []
         scanned_all = []
         # TODO: List of supported file types should be extended
@@ -89,6 +95,18 @@ class Compatibility:
                         types.append("docker")
                         scanned_docker.append(f)
 
+                    elif f.find(".md") > -1:
+                        types.append("markdown")
+                        scanned_markdown.append(f)
+
+                    elif f.find(".css") > -1:
+                        types.append("css")
+                        scanned_css.append(f)
+
+                    elif f.find("nginx.conf") > -1:
+                        types.append("nginx")
+                        scanned_nginx.append(f)
+
                     else:
                         types.append("other")
                         scanned_other.append(f)
@@ -103,6 +121,9 @@ class Compatibility:
             self.scanned_files["html"] = str(scanned_html)
             self.scanned_files["js"] = str(scanned_js)
             self.scanned_files["docker"] = str(scanned_docker)
+            self.scanned_files["markdown"] = str(scanned_markdown)    
+            self.scanned_files["css"] = str(scanned_css)    
+            self.scanned_files["nginx"] = str(scanned_nginx)                
             self.scanned_files["other"] = str(scanned_other)
             self.scanned_files["common"] = str(scanned_all)
 

--- a/src/iac_scan_runner/functionality/compatibility.py
+++ b/src/iac_scan_runner/functionality/compatibility.py
@@ -19,6 +19,7 @@ class Compatibility:
         "css": ["stylelint", "cloc"],
         "nginx": ["gixy", "cloc"],
         "common": ["git-leaks", "git-secrets", "cloc"],
+        "package": ["snyk", "sonar-scanner"],
         "other": []
     }
 
@@ -55,6 +56,7 @@ class Compatibility:
         scanned_markdown = []        
         scanned_css = []
         scanned_nginx = []
+        scanned_package = []
         scanned_other = []
         scanned_all = []
         # TODO: List of supported file types should be extended
@@ -107,6 +109,10 @@ class Compatibility:
                         types.append("nginx")
                         scanned_nginx.append(f)
 
+                    elif "node_modules" in folders and not len(scanned_package):
+                        types.append("package")
+                        scanned_package.append("node_modules")
+
                     else:
                         types.append("other")
                         scanned_other.append(f)
@@ -123,7 +129,8 @@ class Compatibility:
             self.scanned_files["docker"] = str(scanned_docker)
             self.scanned_files["markdown"] = str(scanned_markdown)    
             self.scanned_files["css"] = str(scanned_css)    
-            self.scanned_files["nginx"] = str(scanned_nginx)                
+            self.scanned_files["nginx"] = str(scanned_nginx)
+            self.scanned_files["package"] = str(scanned_package)          
             self.scanned_files["other"] = str(scanned_other)
             self.scanned_files["common"] = str(scanned_all)
 


### PR DESCRIPTION
Add the five remaining checks (markdown-lint, stylelint, gixy, sonar-scanner, snyk) to the compatibility matrix.
The checks are going to have to also be added to `results_summary.py` so as to avoid the
"Not fully supported yet" status.
In `sonar_scanner.py` the `-Dsonar.login=` argument should be fixed to `-Dsonar.token=`.
At the moment Gixy requires Nginx to be installed to work, this is still yet to be fixed. 